### PR TITLE
Replace old image of early Atree contribution stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ Some of my open source work is described here.
 
 ## Design & Implementation
 
-![image](https://user-images.githubusercontent.com/57072051/145697520-4dc89ec2-435b-46f1-8e2c-f9e8ba0ca1df.png)
+<!-- ![fxamacker-onflow-atree-contributions](https://github.com/user-attachments/assets/81e44838-e1ab-4282-9c88-762055f412c5) -->
+
+<img src="https://github.com/user-attachments/assets/81e44838-e1ab-4282-9c88-762055f412c5" width="720">
+
+<!-- ![image](https://user-images.githubusercontent.com/57072051/145697520-4dc89ec2-435b-46f1-8e2c-f9e8ba0ca1df.png) -->
 
 __[onflow/atree](https://github.com/onflow/atree)__: Atree provides scalable arrays and maps.  It is used by [Cadence](https://github.com/onflow/cadence) in the [Flow Blockchain](https://www.onflow.org/).
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,10 @@ Some of my open source work is described here.
 
 ## Design & Implementation
 
-<!-- ![fxamacker-onflow-atree-contributions](https://github.com/user-attachments/assets/81e44838-e1ab-4282-9c88-762055f412c5) -->
-
-<img src="https://github.com/user-attachments/assets/81e44838-e1ab-4282-9c88-762055f412c5" width="720">
 
 <!-- ![image](https://user-images.githubusercontent.com/57072051/145697520-4dc89ec2-435b-46f1-8e2c-f9e8ba0ca1df.png) -->
+
+<img src="https://github.com/user-attachments/assets/81e44838-e1ab-4282-9c88-762055f412c5" width="720" alt="fxamacker stats in atree">
 
 __[onflow/atree](https://github.com/onflow/atree)__: Atree provides scalable arrays and maps.  It is used by [Cadence](https://github.com/onflow/cadence) in the [Flow Blockchain](https://www.onflow.org/).
 


### PR DESCRIPTION
Replace the old image of atree contributions during initial design/implementation/release in 2021 with a current image (roughly atree's 4th anniversary now).

This weekend, I used GitHub's "Soft dark" mode and zoomed 400% on the contribution chart generated by GitHub.  Then added "Go (Golang)" and repo name to the screenshot using "Noto Sans" font in graphite.rs online editor.